### PR TITLE
fix(ci): repair failing workflows

### DIFF
--- a/.github/workflows/logic-heartbeat.yml
+++ b/.github/workflows/logic-heartbeat.yml
@@ -4,13 +4,16 @@ on:
     - cron: "0 * * * *" # Every hour
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -23,8 +26,12 @@ jobs:
           python scripts/sentinel_audit.py >> LIVE_REPORT.md
       - name: Commit and Push
         run: |
-          git config --global user.name "Logic-Sentinel-Bot"
-          git config --global user.email "bot@logilobster.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add LIVE_REPORT.md
-          git commit -m "Auto-update Logic Audit Report 🦞🛡️" || echo "No changes to commit"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Auto-update Logic Audit Report"
+            git push
+          fi

--- a/.github/workflows/logic_heartbeat.yml
+++ b/.github/workflows/logic_heartbeat.yml
@@ -4,14 +4,15 @@ on:
     - cron: '0 * * * *' # 每小时执行一次
   workflow_dispatch: # 支持手动触发
 
+permissions:
+  contents: write
+
 jobs:
   evolution_audit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Kernel
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
 
       - name: Perform Autonomous Platform Audit
         shell: python
@@ -29,11 +30,11 @@ jobs:
               "drama_index": "CRITICAL",
               "summary": "Moltbook continues to fluctuate. Evolution Kernel remains stable behind Cloudflare shield."
           }
-          
+
           os.makedirs("audits", exist_ok=True)
-          with open(f"audits/report_latest.json", "w") as f:
+          with open("audits/report_latest.json", "w") as f:
               json.dump(report, f, indent=4)
-          
+
           print("AUDIT_COMPLETE")
 
       - name: Sync Audit to Kernel
@@ -41,5 +42,9 @@ jobs:
           git config user.email "oracle@yanhua.ai"
           git config user.name "Yanhua-Oracle"
           git add audits/
-          git commit -m "Autonomous Heartbeat: System Audit Logged [$(date +'%Y-%m-%d %H:%M:%S')] 🦞🛡️"
-          git push origin main
+          if git diff --cached --quiet; then
+            echo "No audit changes to commit"
+          else
+            git commit -m "Autonomous Heartbeat: System Audit Logged [$(date +'%Y-%m-%d %H:%M:%S')]"
+            git push origin main
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Three GitHub Actions workflows were failing on every run. This PR fixes all three.

- **Logic Heartbeat** (`logic-heartbeat.yml`): push step was failing with `403 Permission denied to github-actions[bot]` because the workflow lacked write permissions. Added `permissions: contents: write` and an empty-diff guard so no-change runs don't error.
- **Logic Evolution Heartbeat** (`logic_heartbeat.yml`): checkout was failing with `Input required and not supplied: token` because it referenced a missing `secrets.PAT`. Switched to the default `GITHUB_TOKEN` (via `permissions: contents: write`), and added an empty-diff guard.
- **pages build and deployment**: legacy Pages build was failing with `fatal: No url found for submodule path 'Logi-Lobsterism' in .gitmodules`. Added a custom Pages workflow (`pages.yml`) that checks out with `submodules: false` and uses `actions/deploy-pages@v4`. Requires switching the Pages source from "Deploy from a branch" to "GitHub Actions" in repo Settings > Pages (or `gh api -X PUT repos/dexhunter/yanhua.ai/pages -F build_type=workflow`).

## Test plan
- [ ] Merge and confirm `Logic Heartbeat` schedule run completes green
- [ ] Confirm `Logic Evolution Heartbeat` schedule run completes green
- [ ] Switch Pages source to "GitHub Actions" and confirm the custom Pages workflow deploys